### PR TITLE
Pin repeatedly dependency to version 2.1.1 to fix type mismatch

### DIFF
--- a/gleam.toml
+++ b/gleam.toml
@@ -23,7 +23,7 @@ gleam_otp = ">= 0.10.0 and < 1.0.0"
 birl = ">= 1.7.1 and < 2.0.0"
 logging = ">= 1.3.0 and < 2.0.0"
 stratus = ">= 0.9.0 and < 1.0.0"
-repeatedly = ">= 2.1.1 and < 3.0.0"
+repeatedly = ">= 2.1.1 and < 2.1.2"
 bravo = ">= 4.0.1 and < 5.0.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This PR temporally resolves a compatibility issue with the repeatedly package version 2.1.2, which causes a type mismatch error. 
Running tests with repeatedly 2.1.2 triggers this error:

```
discord_gleam/ws/event_loop.gleam:68:53
   │  
68 │ repeatedly.call(heartbeat, Nil, fn(_state, _count_) {
   │ ╭─────────────────────────────────────────────────^
69 │ │ let packet =
70 │ │   "{\"op\": 1, \"d\": null, \"s\": "
71 │ │   <> int.to_string(state.s)
   · │
81 │ │ stratus.send_text_message(conn, packet)
82 │ │ })
   │ ╰─────────────────────────────^

Expected type:
  fn(Nil, Int) -> Nil  

Found type:  
  fn(Nil, Int) -> Result(Nil, socket.SocketReason)  

```
Downgrading repeatedly to version 2.1.1 resolves the issue.

Updated gleam.toml:

    repeatedly = ">= 2.1.1 and < 2.1.2"

Next Steps

Investigate the changes in repeatedly 2.1.2 to identify why the callback signature changed and adapt the code to restore compatibility.