### PR TITLE
Add direct message intent

### DIFF
--- a/examples/kick.gleam
+++ b/examples/kick.gleam
@@ -3,6 +3,7 @@ import discord_gleam/discord/intents
 import discord_gleam/event_handler
 import discord_gleam/types/message
 import gleam/list
+import gleam/option.{Some}
 import gleam/string
 import logging
 
@@ -30,8 +31,8 @@ fn event_handler(bot, packet: event_handler.Packet) {
     event_handler.MessagePacket(message) -> {
       logging.log(logging.Info, "Message: " <> message.d.content)
 
-      case string.starts_with(message.d.content, "!kick ") {
-        True -> {
+      case string.starts_with(message.d.content, "!kick "), message.d.guild_id {
+        True, Some(guild_id) -> {
           let args = string.split(message.d.content, " ")
 
           let args = case list.pop(args, fn(x) { x == "!kick" }) {
@@ -54,8 +55,7 @@ fn event_handler(bot, packet: event_handler.Packet) {
 
           let reason = string.join(args, " ")
 
-          let resp =
-            discord_gleam.kick_member(bot, message.d.guild_id, user, reason)
+          let resp = discord_gleam.kick_member(bot, guild_id, user, reason)
 
           case resp.0 {
             "OK" -> {
@@ -76,7 +76,7 @@ fn event_handler(bot, packet: event_handler.Packet) {
             }
           }
         }
-        False -> Nil
+        _, _ -> Nil
       }
     }
     _ -> Nil

--- a/src/discord_gleam/discord/intents.gleam
+++ b/src/discord_gleam/discord/intents.gleam
@@ -1,5 +1,5 @@
 pub type Intents {
-  Intents(guild_messages: Bool, message_content: Bool)
+  Intents(guild_messages: Bool, message_content: Bool, direct_messages: Bool)
 }
 
 pub fn intents_to_bitfield(intents: Intents) -> Int {
@@ -8,6 +8,12 @@ pub fn intents_to_bitfield(intents: Intents) -> Int {
   let bitfield = case intents.guild_messages {
     True -> bitfield + 512
     // 1 << 9
+    False -> bitfield
+  }
+
+  let bitfield = case intents.direct_messages {
+    True -> bitfield + 4096
+    // 1 << 12
     False -> bitfield
   }
 

--- a/src/discord_gleam/ws/packets/message.gleam
+++ b/src/discord_gleam/ws/packets/message.gleam
@@ -1,6 +1,7 @@
 import discord_gleam/discord/snowflake.{type Snowflake}
 import gleam/dynamic/decode
 import gleam/json
+import gleam/option.{type Option, None, Some}
 import gleam/result
 
 pub type MessageAuthor {
@@ -11,7 +12,7 @@ pub type MessagePacketData {
   MessagePacketData(
     content: String,
     id: Snowflake,
-    guild_id: Snowflake,
+    guild_id: Option(Snowflake),
     channel_id: Snowflake,
     author: MessageAuthor,
   )
@@ -29,7 +30,11 @@ pub fn string_to_data(encoded: String) -> Result(MessagePacket, String) {
     use d <- decode.field("d", {
       use content <- decode.field("content", decode.string)
       use id <- decode.field("id", snowflake.decoder())
-      use guild_id <- decode.field("guild_id", snowflake.decoder())
+      use guild_id <- decode.optional_field(
+        "guild_id",
+        None,
+        snowflake.decoder() |> decode.map(Some),
+      )
       use channel_id <- decode.field("channel_id", snowflake.decoder())
       use author <- decode.field("author", {
         use id <- decode.field("id", snowflake.decoder())

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -5,7 +5,7 @@ import discord_gleam/event_handler
 import discord_gleam/types/bot
 import discord_gleam/types/message
 import discord_gleam/types/slash_command
-import gleam/option
+import gleam/option.{Some}
 import gleam/string
 import logging
 
@@ -114,8 +114,8 @@ fn event_handler(bot: bot.Bot, packet: event_handler.Packet) {
         False -> Nil
       }
 
-      case message.d.content {
-        "!kick " <> args -> {
+      case message.d.content, message.d.guild_id {
+        "!kick " <> args, Some(guild_id) -> {
           let args = string.split(args, " ")
           let #(user, args) = case args {
             [user, ..args] -> #(user, args)
@@ -127,8 +127,7 @@ fn event_handler(bot: bot.Bot, packet: event_handler.Packet) {
 
           let reason = string.join(args, " ")
 
-          let resp =
-            discord_gleam.kick_member(bot, message.d.guild_id, user, reason)
+          let resp = discord_gleam.kick_member(bot, guild_id, user, reason)
 
           case resp.0 {
             "OK" -> {
@@ -149,10 +148,10 @@ fn event_handler(bot: bot.Bot, packet: event_handler.Packet) {
             }
           }
         }
-        _ -> Nil
+        _, _ -> Nil
       }
-      case message.d.content {
-        "!ban " <> args -> {
+      case message.d.content, message.d.guild_id {
+        "!ban " <> args, Some(guild_id) -> {
           let args = string.split(args, " ")
           let #(user, args) = case args {
             [user, ..args] -> #(user, args)
@@ -164,8 +163,7 @@ fn event_handler(bot: bot.Bot, packet: event_handler.Packet) {
 
           let reason = string.join(args, " ")
 
-          let resp =
-            discord_gleam.ban_member(bot, message.d.guild_id, user, reason)
+          let resp = discord_gleam.ban_member(bot, guild_id, user, reason)
 
           case resp.0 {
             "OK" -> {
@@ -186,7 +184,7 @@ fn event_handler(bot: bot.Bot, packet: event_handler.Packet) {
             }
           }
         }
-        _ -> Nil
+        _, _ -> Nil
       }
     }
     event_handler.MessageDeletePacket(deleted) -> {

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -17,7 +17,11 @@ pub fn main(token: String, client_id: String, guild_id: String) {
     discord_gleam.bot(
       token,
       client_id,
-      intents.Intents(message_content: True, guild_messages: True),
+      intents.Intents(
+        message_content: True,
+        guild_messages: True,
+        direct_messages: True,
+      ),
     )
 
   let test_cmd =


### PR DESCRIPTION
This PR adds the ability for bots to receive direct messages. In order to do so, it adds a `direct_messages` intent and makes `guild_id` optional on message packets.

Technically, the `direct_messages` intent is not backwards compatible. Let me know what you think.

I've also added a `d` to `GenericPacket`s with a type of `Dynamic`. This means users of the library can decode their own packets in the future.