### PR TITLE
Add `guild_presences` intent and few `guild_members` events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 erl_crash.dump
 .env
 .env.local
+temp.json

--- a/src/discord_gleam.gleam
+++ b/src/discord_gleam.gleam
@@ -17,6 +17,7 @@ import discord_gleam/ws/event_loop
 import discord_gleam/ws/packets/interaction_create
 import gleam/dict
 import gleam/list
+import gleam/option
 
 /// Create a new bot instance.
 /// 
@@ -38,6 +39,7 @@ pub fn bot(
     client_id: client_id,
     intents: intents,
     cache: bot.Cache(messages: booklet.new(dict.new())),
+    websocket_name: option.None,
   )
 }
 

--- a/src/discord_gleam.gleam
+++ b/src/discord_gleam.gleam
@@ -289,3 +289,4 @@ pub fn interaction_reply_message(
 ) -> Result(Nil, error.DiscordError) {
   endpoints.interaction_send_text(interaction, message, ephemeral)
 }
+// TODO: import function to request guild members to the root module

--- a/src/discord_gleam.gleam
+++ b/src/discord_gleam.gleam
@@ -289,4 +289,3 @@ pub fn interaction_reply_message(
 ) -> Result(Nil, error.DiscordError) {
   endpoints.interaction_send_text(interaction, message, ephemeral)
 }
-// TODO: import function to request guild members to the root module

--- a/src/discord_gleam/event_handler.gleam
+++ b/src/discord_gleam/event_handler.gleam
@@ -64,6 +64,7 @@ pub type Packet {
   /// GUILD_MEMBER_REMOVE event
   GuildMemberRemovePacket(guild_member_remove.GuildMemberRemove)
 
+  // TODO: Add support for GUILD_MEMBERS_CHUNK, GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE
   /// `PRESENCE_UPDATE` event
   PresenceUpdatePacket(presence_update.PresenceUpdatePacket)
 

--- a/src/discord_gleam/event_handler.gleam
+++ b/src/discord_gleam/event_handler.gleam
@@ -16,6 +16,7 @@ import discord_gleam/ws/packets/message
 import discord_gleam/ws/packets/message_delete
 import discord_gleam/ws/packets/message_delete_bulk
 import discord_gleam/ws/packets/message_update
+import discord_gleam/ws/packets/presence_update
 import discord_gleam/ws/packets/ready
 import gleam/dict
 import gleam/list
@@ -62,6 +63,9 @@ pub type Packet {
 
   /// GUILD_MEMBER_REMOVE event
   GuildMemberRemovePacket(guild_member_remove.GuildMemberRemove)
+
+  /// `PRESENCE_UPDATE` event
+  PresenceUpdatePacket(presence_update.PresenceUpdatePacket)
 
   /// When we receive a packet that we don't know how to handle
   UnknownPacket(generic.GenericPacket)
@@ -324,6 +328,20 @@ fn decode_packet(msg: String) -> Packet {
           logging.log(
             logging.Error,
             "Failed to decode GUILD_MEMBER_REMOVE packet: "
+              <> error.json_decode_error_to_string(err),
+          )
+
+          UnknownPacket(generic_packet)
+        }
+      }
+
+    "PRESENCE_UPDATE" ->
+      case presence_update.string_to_data(msg) {
+        Ok(data) -> PresenceUpdatePacket(data)
+        Error(err) -> {
+          logging.log(
+            logging.Error,
+            "Failed to decode PRESENCE_UPDATE packet: "
               <> error.json_decode_error_to_string(err),
           )
 

--- a/src/discord_gleam/event_handler.gleam
+++ b/src/discord_gleam/event_handler.gleam
@@ -8,6 +8,7 @@ import discord_gleam/ws/packets/generic
 import discord_gleam/ws/packets/guild_ban_add
 import discord_gleam/ws/packets/guild_ban_remove
 import discord_gleam/ws/packets/guild_member_remove
+import discord_gleam/ws/packets/guild_members_chunk
 import discord_gleam/ws/packets/guild_role_create
 import discord_gleam/ws/packets/guild_role_delete
 import discord_gleam/ws/packets/guild_role_update
@@ -63,8 +64,10 @@ pub type Packet {
 
   /// GUILD_MEMBER_REMOVE event
   GuildMemberRemovePacket(guild_member_remove.GuildMemberRemove)
+  /// `GUILD_MEMBERS_CHUNK` event
+  GuildMembersChunkPacket(guild_members_chunk.GuildMembersChunkPacket)
 
-  // TODO: Add support for GUILD_MEMBERS_CHUNK, GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE
+  // TODO: Add support for GUILD_MEMBER_ADD, GUILD_MEMBER_UPDATE
   /// `PRESENCE_UPDATE` event
   PresenceUpdatePacket(presence_update.PresenceUpdatePacket)
 
@@ -332,6 +335,19 @@ fn decode_packet(msg: String) -> Packet {
               <> error.json_decode_error_to_string(err),
           )
 
+          UnknownPacket(generic_packet)
+        }
+      }
+
+    "GUILD_MEMBERS_CHUNK" ->
+      case guild_members_chunk.string_to_data(msg) {
+        Ok(data) -> GuildMembersChunkPacket(data)
+        Error(err) -> {
+          logging.log(
+            logging.Error,
+            "Failed to decode GUILD_MEMBERS_CHUNK packet: "
+              <> error.json_decode_error_to_string(err),
+          )
           UnknownPacket(generic_packet)
         }
       }

--- a/src/discord_gleam/types/activity.gleam
+++ b/src/discord_gleam/types/activity.gleam
@@ -1,0 +1,259 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import gleam/dynamic/decode
+import gleam/option.{type Option, None}
+import gleam/string
+
+pub type ActivityTimestamp {
+  ActivityTimestamp(start: Option(Int), end: Option(Int))
+}
+
+pub type ActivityEmoji {
+  ActivityEmoji(name: String, id: Option(Snowflake), animated: Option(Bool))
+}
+
+pub type ActivityParty {
+  ActivityParty(id: Option(String), size: #(Int, Int))
+}
+
+pub type ActivityAssets {
+  ActivityAssets(
+    large_image: Option(String),
+    large_text: Option(String),
+    large_url: Option(String),
+    small_image: Option(String),
+    small_text: Option(String),
+    small_url: Option(String),
+  )
+}
+
+pub type ActivitySecrets {
+  ActivitySecrets(
+    join: Option(String),
+    spectate: Option(String),
+    match: Option(String),
+  )
+}
+
+pub type ActivityButton {
+  ActivityButton(label: String, url: String)
+}
+
+/// See https://discord.com/developers/docs/events/gateway-events#activity-object
+pub type Activity {
+  Activity(
+    name: String,
+    type_: Int,
+    url: Option(String),
+    created_at: Int,
+    timestamps: Option(ActivityTimestamp),
+    application_id: Option(Snowflake),
+    status_display_type: Option(Int),
+    details: Option(String),
+    details_url: Option(String),
+    state: Option(String),
+    state_url: Option(String),
+    emoji: Option(ActivityEmoji),
+    party: Option(ActivityParty),
+    assets: Option(ActivityAssets),
+    secrets: Option(ActivitySecrets),
+    instance: Option(Bool),
+    flags: Option(Int),
+    buttons: Option(List(ActivityButton)),
+  )
+}
+
+pub fn from_json_decoder() -> decode.Decoder(Activity) {
+  use name <- decode.field("name", decode.string)
+  use type_ <- decode.field("type", decode.int)
+  use url <- decode.optional_field("url", None, decode.optional(decode.string))
+  use created_at <- decode.field("created_at", decode.int)
+  use timestamps <- decode.optional_field(
+    "timestamps",
+    None,
+    decode.optional(activity_timestamp_decoder()),
+  )
+  use application_id <- decode.optional_field(
+    "application_id",
+    None,
+    decode.optional(snowflake.decoder()),
+  )
+  use status_display_type <- decode.optional_field(
+    "status_display_type",
+    None,
+    decode.optional(decode.int),
+  )
+  use details <- decode.optional_field(
+    "details",
+    None,
+    decode.optional(decode.string),
+  )
+  use details_url <- decode.optional_field(
+    "details_url",
+    None,
+    decode.optional(decode.string),
+  )
+  use state <- decode.optional_field(
+    "state",
+    None,
+    decode.optional(decode.string),
+  )
+  use state_url <- decode.optional_field(
+    "state_url",
+    None,
+    decode.optional(decode.string),
+  )
+  use emoji <- decode.optional_field(
+    "emoji",
+    None,
+    decode.optional(activity_emoji_decoder()),
+  )
+  use party <- decode.optional_field(
+    "party",
+    None,
+    decode.optional(activity_party_decoder()),
+  )
+  use assets <- decode.optional_field(
+    "assets",
+    None,
+    decode.optional(activity_assets_decoder()),
+  )
+  use secrets <- decode.optional_field(
+    "secrets",
+    None,
+    decode.optional(activity_secrets_decoder()),
+  )
+  use instance <- decode.optional_field(
+    "instance",
+    None,
+    decode.optional(decode.bool),
+  )
+  use flags <- decode.optional_field("flags", None, decode.optional(decode.int))
+  use buttons <- decode.optional_field(
+    "buttons",
+    None,
+    decode.optional(decode.list(of: activity_button_decoder())),
+  )
+
+  decode.success(Activity(
+    name:,
+    type_:,
+    url:,
+    created_at:,
+    timestamps:,
+    application_id:,
+    status_display_type:,
+    details:,
+    details_url:,
+    state:,
+    state_url:,
+    emoji:,
+    party:,
+    assets:,
+    secrets:,
+    instance:,
+    flags:,
+    buttons:,
+  ))
+}
+
+fn activity_timestamp_decoder() {
+  use start <- decode.optional_field("start", None, decode.optional(decode.int))
+  use end <- decode.optional_field("end", None, decode.optional(decode.int))
+  decode.success(ActivityTimestamp(start:, end:))
+}
+
+fn activity_emoji_decoder() {
+  use name <- decode.field("name", decode.string)
+  use id <- decode.optional_field(
+    "id",
+    None,
+    decode.optional(snowflake.decoder()),
+  )
+  use animated <- decode.optional_field(
+    "animated",
+    None,
+    decode.optional(decode.bool),
+  )
+  decode.success(ActivityEmoji(name:, id:, animated:))
+}
+
+fn activity_party_decoder() {
+  use id <- decode.optional_field("id", None, decode.optional(decode.string))
+  use size <- decode.field("size", decode.list(of: decode.int))
+
+  case size {
+    [current_size, max_size] ->
+      decode.success(ActivityParty(id:, size: #(current_size, max_size)))
+    _ ->
+      decode.failure(
+        ActivityParty(None, #(0, 0)),
+        "Expected list of two ints, but found " <> string.inspect(size),
+      )
+  }
+}
+
+fn activity_assets_decoder() {
+  use large_image <- decode.optional_field(
+    "large_image",
+    None,
+    decode.optional(decode.string),
+  )
+  use large_text <- decode.optional_field(
+    "large_text",
+    None,
+    decode.optional(decode.string),
+  )
+  use large_url <- decode.optional_field(
+    "large_url",
+    None,
+    decode.optional(decode.string),
+  )
+  use small_image <- decode.optional_field(
+    "small_image",
+    None,
+    decode.optional(decode.string),
+  )
+  use small_text <- decode.optional_field(
+    "small_text",
+    None,
+    decode.optional(decode.string),
+  )
+  use small_url <- decode.optional_field(
+    "small_url",
+    None,
+    decode.optional(decode.string),
+  )
+  decode.success(ActivityAssets(
+    large_image:,
+    large_text:,
+    large_url:,
+    small_image:,
+    small_text:,
+    small_url:,
+  ))
+}
+
+fn activity_secrets_decoder() {
+  use join <- decode.optional_field(
+    "join",
+    None,
+    decode.optional(decode.string),
+  )
+  use spectate <- decode.optional_field(
+    "spectate",
+    None,
+    decode.optional(decode.string),
+  )
+  use match <- decode.optional_field(
+    "match",
+    None,
+    decode.optional(decode.string),
+  )
+  decode.success(ActivitySecrets(join:, spectate:, match:))
+}
+
+fn activity_button_decoder() {
+  use label <- decode.field("label", decode.string)
+  use url <- decode.field("url", decode.string)
+  decode.success(ActivityButton(label:, url:))
+}

--- a/src/discord_gleam/types/bot.gleam
+++ b/src/discord_gleam/types/bot.gleam
@@ -3,6 +3,8 @@ import discord_gleam/discord/intents
 import discord_gleam/discord/snowflake.{type Snowflake}
 import discord_gleam/ws/packets/message.{type MessagePacketData}
 import gleam/dict
+import gleam/erlang/process
+import gleam/option.{type Option}
 
 /// The Bot type holds bot data used by a lot of high-level functions
 pub type Bot {
@@ -11,7 +13,13 @@ pub type Bot {
     client_id: Snowflake,
     intents: intents.Intents,
     cache: Cache,
+    websocket_name: Option(process.Name(UserMessage)),
   )
+}
+
+/// Used to send user messages to the websocket process
+pub type UserMessage {
+  SendPacket(packet: String)
 }
 
 /// The cache currently only stores messages, which can be used to for example get deleted messages

--- a/src/discord_gleam/types/guild.gleam
+++ b/src/discord_gleam/types/guild.gleam
@@ -1,0 +1,19 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import gleam/dynamic/decode
+
+/// See https://discord.com/developers/docs/resources/guild#guild-resource \
+pub type Guild {
+  UnavailableGuild(id: Snowflake, unavailable: Bool)
+  // TODO: Implement guild structure
+  Guild(id: Snowflake)
+}
+
+pub fn from_json_decoder() -> decode.Decoder(Guild) {
+  use id <- decode.field("id", snowflake.decoder())
+  use unavailable <- decode.optional_field("unavailable", False, decode.bool)
+
+  case unavailable {
+    True -> decode.success(UnavailableGuild(id:, unavailable:))
+    False -> decode.success(Guild(id:))
+  }
+}

--- a/src/discord_gleam/types/guild_member.gleam
+++ b/src/discord_gleam/types/guild_member.gleam
@@ -1,0 +1,90 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import discord_gleam/types/user
+import gleam/dynamic/decode
+import gleam/option.{type Option, None}
+
+pub type GuildMember {
+  GuildMember(
+    user: user.User,
+    nick: Option(String),
+    avatar: Option(String),
+    banner: Option(String),
+    roles: List(Snowflake),
+    // ISO8601 timestamp?
+    joined_at: String,
+    premium_since: Option(String),
+    deaf: Bool,
+    mute: Bool,
+    flags: Int,
+    pending: Option(Bool),
+    permissions: Option(String),
+    communication_disabled_until: Option(String),
+    avatar_decoration: Option(user.AvatarDecoration),
+  )
+}
+
+pub fn from_json_decoder() -> decode.Decoder(GuildMember) {
+  use user <- decode.field("user", user.from_json_decoder())
+  use nick <- decode.optional_field(
+    "nick",
+    None,
+    decode.optional(decode.string),
+  )
+  use avatar <- decode.optional_field(
+    "avatar",
+    None,
+    decode.optional(decode.string),
+  )
+  use banner <- decode.optional_field(
+    "banner",
+    None,
+    decode.optional(decode.string),
+  )
+  use roles <- decode.field("roles", decode.list(of: snowflake.decoder()))
+  use joined_at <- decode.field("joined_at", decode.string)
+  use premium_since <- decode.optional_field(
+    "premium_since",
+    None,
+    decode.optional(decode.string),
+  )
+  use deaf <- decode.field("deaf", decode.bool)
+  use mute <- decode.field("mute", decode.bool)
+  use flags <- decode.field("flags", decode.int)
+  use pending <- decode.optional_field(
+    "pending",
+    None,
+    decode.optional(decode.bool),
+  )
+  use permissions <- decode.optional_field(
+    "permissions",
+    None,
+    decode.optional(decode.string),
+  )
+  use communication_disabled_until <- decode.optional_field(
+    "communication_disabled_until",
+    None,
+    decode.optional(decode.string),
+  )
+  use avatar_decoration <- decode.optional_field(
+    "avatar_decoration",
+    None,
+    decode.optional(user.avatar_decoration_decoder()),
+  )
+
+  decode.success(GuildMember(
+    user:,
+    nick:,
+    avatar:,
+    banner:,
+    roles:,
+    joined_at:,
+    premium_since:,
+    deaf:,
+    mute:,
+    flags:,
+    pending:,
+    permissions:,
+    communication_disabled_until:,
+    avatar_decoration:,
+  ))
+}

--- a/src/discord_gleam/types/presence.gleam
+++ b/src/discord_gleam/types/presence.gleam
@@ -1,0 +1,73 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import discord_gleam/types/activity
+import gleam/dynamic/decode
+import gleam/option.{type Option, None, Some}
+
+pub type ClientStatus {
+  ClientStatus(
+    desktop: Option(String),
+    mobile: Option(String),
+    web: Option(String),
+  )
+}
+
+// NOTE: `PRESENCE_UPDATE` packet includes only user id?
+
+pub type PresenceUser {
+  PresenceUser(id: Snowflake)
+}
+
+pub type Presence {
+  Presence(
+    user: PresenceUser,
+    // NOTE: does not exist?
+    // guild_id: Snowflake,
+    status: String,
+    activities: List(activity.Activity),
+    client_status: ClientStatus,
+  )
+}
+
+pub fn from_json_decoder() -> decode.Decoder(Presence) {
+  use user <- decode.field("user", presence_user_decoder())
+  // use guild_id <- decode.field("guild_id", snowflake.decoder())
+  use status <- decode.field("status", decode.string)
+  use activities <- decode.field(
+    "activities",
+    decode.list(activity.from_json_decoder()),
+  )
+  use client_status <- decode.field("client_status", client_status_decoder())
+
+  decode.success(Presence(
+    user:,
+    // guild_id:,
+    status:,
+    activities:,
+    client_status:,
+  ))
+}
+
+pub fn presence_user_decoder() -> decode.Decoder(PresenceUser) {
+  use id <- decode.field("id", snowflake.decoder())
+  decode.success(PresenceUser(id:))
+}
+
+pub fn client_status_decoder() {
+  use desktop <- decode.optional_field(
+    "desktop",
+    None,
+    decode.string |> decode.map(Some),
+  )
+  use mobile <- decode.optional_field(
+    "mobile",
+    None,
+    decode.string |> decode.map(Some),
+  )
+  use web <- decode.optional_field(
+    "web",
+    None,
+    decode.string |> decode.map(Some),
+  )
+
+  decode.success(ClientStatus(desktop:, mobile:, web:))
+}

--- a/src/discord_gleam/types/user.gleam
+++ b/src/discord_gleam/types/user.gleam
@@ -33,6 +33,16 @@ pub type User {
   )
 }
 
+pub type AvatarDecoration {
+  AvatarDecoration(asset: String, sku_id: Snowflake)
+}
+
+pub fn avatar_decoration_decoder() -> decode.Decoder(AvatarDecoration) {
+  use asset <- decode.field("asset", decode.string)
+  use sku_id <- decode.field("sku_id", snowflake.decoder())
+  decode.success(AvatarDecoration(asset:, sku_id:))
+}
+
 /// Decode a string to a PartialUser
 pub fn string_to_data(encoded: String) -> Result(User, error.DiscordError) {
   case string.contains(encoded, "401: Unauthorized") {

--- a/src/discord_gleam/ws/commands/request_guild_members.gleam
+++ b/src/discord_gleam/ws/commands/request_guild_members.gleam
@@ -1,0 +1,69 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import discord_gleam/types/bot
+import gleam/erlang/process
+import gleam/json
+import gleam/list
+import gleam/option.{type Option, None, Some}
+
+pub type RequestGuildMembersOption {
+  Query(String, limit: Option(Int))
+  UserIds(List(Snowflake))
+}
+
+pub type RequestGuildMembersData {
+  RequestGuildMembersData(
+    guild_id: Snowflake,
+    option: RequestGuildMembersOption,
+    presences: Option(Bool),
+    nonce: Option(String),
+  )
+}
+
+pub fn request_guild_members(
+  bot: bot.Bot,
+  guild_id guild_id: Snowflake,
+  option option: RequestGuildMembersOption,
+  presences presences: Option(Bool),
+  nonce nonce: Option(String),
+) -> Nil {
+  let data = RequestGuildMembersData(guild_id:, option:, presences:, nonce:)
+
+  let packet =
+    json.object([#("op", json.int(8)), #("d", data_to_json(data))])
+    |> json.to_string()
+
+  case bot.websocket_name {
+    Some(name) -> {
+      process.send(process.named_subject(name), bot.SendPacket(packet))
+    }
+    None -> Nil
+  }
+}
+
+fn data_to_json(data: RequestGuildMembersData) -> json.Json {
+  let fields = [
+    #("guild_id", json.string(data.guild_id)),
+  ]
+
+  let fields = case data.presences {
+    option.Some(presences) ->
+      list.append(fields, [#("presences", json.bool(presences))])
+    option.None -> fields
+  }
+
+  let fields = case data.nonce {
+    option.Some(nonce) -> list.append(fields, [#("nonce", json.string(nonce))])
+    option.None -> fields
+  }
+
+  case data.option {
+    Query(query, limit) ->
+      list.append(fields, [
+        #("query", json.string(query)),
+        #("limit", json.int(option.unwrap(limit, 0))),
+      ])
+    UserIds(user_ids) ->
+      list.append(fields, [#("user_ids", json.array(user_ids, of: json.string))])
+  }
+  |> json.object()
+}

--- a/src/discord_gleam/ws/event_loop.gleam
+++ b/src/discord_gleam/ws/event_loop.gleam
@@ -228,7 +228,7 @@ pub fn main(
         stratus.User(bot.SendPacket(packet)) -> {
           logging.log(logging.Debug, "User packet: " <> packet)
 
-          let _ = stratus.send_text_message(conn, packet) |> echo
+          let _ = stratus.send_text_message(conn, packet)
 
           stratus.continue(state)
         }

--- a/src/discord_gleam/ws/packets/guild_members_chunk.gleam
+++ b/src/discord_gleam/ws/packets/guild_members_chunk.gleam
@@ -1,0 +1,81 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import discord_gleam/types/guild_member
+import discord_gleam/types/presence
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{type Option, None}
+
+pub type GuildMembersChunkContent {
+  GuildMembersChunkContent(
+    guild_id: Snowflake,
+    members: List(guild_member.GuildMember),
+    chunk_index: Int,
+    chunk_count: Int,
+    not_found: Option(List(Snowflake)),
+    presences: Option(List(presence.Presence)),
+    nonce: Option(String),
+  )
+}
+
+pub type GuildMembersChunkData {
+  Final(GuildMembersChunkContent)
+  Next(GuildMembersChunkContent)
+}
+
+pub type GuildMembersChunkPacket {
+  GuildMembersChunkPacket(t: String, s: Int, op: Int, d: GuildMembersChunkData)
+}
+
+pub fn string_to_data(
+  encoded: String,
+) -> Result(GuildMembersChunkPacket, json.DecodeError) {
+  let decoder = {
+    use t <- decode.field("t", decode.string)
+    use s <- decode.field("s", decode.int)
+    use op <- decode.field("op", decode.int)
+    use d <- decode.field("d", {
+      use guild_id <- decode.field("guild_id", snowflake.decoder())
+      use members <- decode.field(
+        "members",
+        decode.list(of: guild_member.from_json_decoder()),
+      )
+      use chunk_index <- decode.field("chunk_index", decode.int)
+      use chunk_count <- decode.field("chunk_count", decode.int)
+      use not_found <- decode.optional_field(
+        "not_found",
+        None,
+        decode.optional(decode.list(of: snowflake.decoder())),
+      )
+      use presences <- decode.optional_field(
+        "presences",
+        None,
+        decode.optional(decode.list(of: presence.from_json_decoder())),
+      )
+      use nonce <- decode.optional_field(
+        "nonce",
+        None,
+        decode.optional(decode.string),
+      )
+
+      let content =
+        GuildMembersChunkContent(
+          guild_id:,
+          members:,
+          chunk_index:,
+          chunk_count:,
+          not_found:,
+          presences:,
+          nonce:,
+        )
+
+      decode.success(case chunk_index + 1 == chunk_count {
+        True -> Final(content)
+        False -> Next(content)
+      })
+    })
+
+    decode.success(GuildMembersChunkPacket(t:, s:, op:, d:))
+  }
+
+  json.parse(from: encoded, using: decoder)
+}

--- a/src/discord_gleam/ws/packets/guild_members_chunk.gleam
+++ b/src/discord_gleam/ws/packets/guild_members_chunk.gleam
@@ -5,8 +5,8 @@ import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{type Option, None}
 
-pub type GuildMembersChunkContent {
-  GuildMembersChunkContent(
+pub type GuildMembersChunkData {
+  GuildMembersChunkData(
     guild_id: Snowflake,
     members: List(guild_member.GuildMember),
     chunk_index: Int,
@@ -15,11 +15,6 @@ pub type GuildMembersChunkContent {
     presences: Option(List(presence.Presence)),
     nonce: Option(String),
   )
-}
-
-pub type GuildMembersChunkData {
-  Final(GuildMembersChunkContent)
-  Next(GuildMembersChunkContent)
 }
 
 pub type GuildMembersChunkPacket {
@@ -57,21 +52,15 @@ pub fn string_to_data(
         decode.optional(decode.string),
       )
 
-      let content =
-        GuildMembersChunkContent(
-          guild_id:,
-          members:,
-          chunk_index:,
-          chunk_count:,
-          not_found:,
-          presences:,
-          nonce:,
-        )
-
-      decode.success(case chunk_index + 1 == chunk_count {
-        True -> Final(content)
-        False -> Next(content)
-      })
+      decode.success(GuildMembersChunkData(
+        guild_id:,
+        members:,
+        chunk_index:,
+        chunk_count:,
+        not_found:,
+        presences:,
+        nonce:,
+      ))
     })
 
     decode.success(GuildMembersChunkPacket(t:, s:, op:, d:))

--- a/src/discord_gleam/ws/packets/presence_update.gleam
+++ b/src/discord_gleam/ws/packets/presence_update.gleam
@@ -1,0 +1,90 @@
+import discord_gleam/discord/snowflake.{type Snowflake}
+import discord_gleam/types/activity
+import gleam/dynamic/decode
+import gleam/json
+import gleam/option.{type Option, None, Some}
+
+pub type PartialUser {
+  PartialUser(id: Snowflake)
+}
+
+pub type ClientStatus {
+  ClientStatus(
+    desktop: Option(String),
+    mobile: Option(String),
+    web: Option(String),
+  )
+}
+
+pub type PresenceUpdatePacketData {
+  PresenceUpdatePacketData(
+    user: PartialUser,
+    guild_id: Snowflake,
+    status: String,
+    activities: List(activity.Activity),
+    client_status: ClientStatus,
+  )
+}
+
+pub type PresenceUpdatePacket {
+  PresenceUpdatePacket(t: String, s: Int, op: Int, d: PresenceUpdatePacketData)
+}
+
+pub fn string_to_data(
+  encoded: String,
+) -> Result(PresenceUpdatePacket, json.DecodeError) {
+  let decoder = {
+    use t <- decode.field("t", decode.string)
+    use s <- decode.field("s", decode.int)
+    use op <- decode.field("op", decode.int)
+    use d <- decode.field("d", {
+      use user <- decode.field("user", partial_user_decoder())
+      use guild_id <- decode.field("guild_id", snowflake.decoder())
+      use status <- decode.field("status", decode.string)
+      use activities <- decode.field(
+        "activities",
+        decode.list(activity.from_json_decoder()),
+      )
+      use client_status <- decode.field(
+        "client_status",
+        client_status_decoder(),
+      )
+
+      decode.success(PresenceUpdatePacketData(
+        user:,
+        guild_id:,
+        status:,
+        activities:,
+        client_status:,
+      ))
+    })
+    decode.success(PresenceUpdatePacket(t:, s:, op:, d:))
+  }
+
+  json.parse(from: encoded, using: decoder)
+}
+
+fn partial_user_decoder() {
+  use id <- decode.field("id", snowflake.decoder())
+  decode.success(PartialUser(id:))
+}
+
+fn client_status_decoder() {
+  use desktop <- decode.optional_field(
+    "desktop",
+    None,
+    decode.string |> decode.map(Some),
+  )
+  use mobile <- decode.optional_field(
+    "mobile",
+    None,
+    decode.string |> decode.map(Some),
+  )
+  use web <- decode.optional_field(
+    "web",
+    None,
+    decode.string |> decode.map(Some),
+  )
+
+  decode.success(ClientStatus(desktop:, mobile:, web:))
+}

--- a/src/discord_gleam/ws/packets/presence_update.gleam
+++ b/src/discord_gleam/ws/packets/presence_update.gleam
@@ -1,34 +1,9 @@
-import discord_gleam/discord/snowflake.{type Snowflake}
-import discord_gleam/types/activity
+import discord_gleam/types/presence
 import gleam/dynamic/decode
 import gleam/json
-import gleam/option.{type Option, None, Some}
-
-// TODO: Move to types/user.gleam?
-pub type PartialUser {
-  PartialUser(id: Snowflake)
-}
-
-pub type ClientStatus {
-  ClientStatus(
-    desktop: Option(String),
-    mobile: Option(String),
-    web: Option(String),
-  )
-}
-
-pub type PresenceUpdatePacketData {
-  PresenceUpdatePacketData(
-    user: PartialUser,
-    guild_id: Snowflake,
-    status: String,
-    activities: List(activity.Activity),
-    client_status: ClientStatus,
-  )
-}
 
 pub type PresenceUpdatePacket {
-  PresenceUpdatePacket(t: String, s: Int, op: Int, d: PresenceUpdatePacketData)
+  PresenceUpdatePacket(t: String, s: Int, op: Int, d: presence.Presence)
 }
 
 pub fn string_to_data(
@@ -38,54 +13,9 @@ pub fn string_to_data(
     use t <- decode.field("t", decode.string)
     use s <- decode.field("s", decode.int)
     use op <- decode.field("op", decode.int)
-    use d <- decode.field("d", {
-      use user <- decode.field("user", partial_user_decoder())
-      use guild_id <- decode.field("guild_id", snowflake.decoder())
-      use status <- decode.field("status", decode.string)
-      use activities <- decode.field(
-        "activities",
-        decode.list(activity.from_json_decoder()),
-      )
-      use client_status <- decode.field(
-        "client_status",
-        client_status_decoder(),
-      )
-
-      decode.success(PresenceUpdatePacketData(
-        user:,
-        guild_id:,
-        status:,
-        activities:,
-        client_status:,
-      ))
-    })
+    use d <- decode.field("d", presence.from_json_decoder())
     decode.success(PresenceUpdatePacket(t:, s:, op:, d:))
   }
 
   json.parse(from: encoded, using: decoder)
-}
-
-fn partial_user_decoder() {
-  use id <- decode.field("id", snowflake.decoder())
-  decode.success(PartialUser(id:))
-}
-
-fn client_status_decoder() {
-  use desktop <- decode.optional_field(
-    "desktop",
-    None,
-    decode.string |> decode.map(Some),
-  )
-  use mobile <- decode.optional_field(
-    "mobile",
-    None,
-    decode.string |> decode.map(Some),
-  )
-  use web <- decode.optional_field(
-    "web",
-    None,
-    decode.string |> decode.map(Some),
-  )
-
-  decode.success(ClientStatus(desktop:, mobile:, web:))
 }

--- a/src/discord_gleam/ws/packets/presence_update.gleam
+++ b/src/discord_gleam/ws/packets/presence_update.gleam
@@ -4,6 +4,7 @@ import gleam/dynamic/decode
 import gleam/json
 import gleam/option.{type Option, None, Some}
 
+// TODO: Move to types/user.gleam?
 pub type PartialUser {
   PartialUser(id: Snowflake)
 }

--- a/src/discord_gleam/ws/packets/ready.gleam
+++ b/src/discord_gleam/ws/packets/ready.gleam
@@ -1,3 +1,4 @@
+import discord_gleam/types/guild
 import discord_gleam/types/user
 import gleam/dynamic/decode
 import gleam/json
@@ -6,6 +7,7 @@ pub type ReadyData {
   ReadyData(
     v: Int,
     user: user.User,
+    guilds: List(guild.Guild),
     session_id: String,
     resume_gateway_url: String,
   )
@@ -27,13 +29,24 @@ pub fn string_to_data(encoded: String) -> Result(ReadyPacket, json.DecodeError) 
 
       use user <- decode.field("user", user.from_json_decoder())
 
+      use guilds <- decode.field(
+        "guilds",
+        decode.list(guild.from_json_decoder()),
+      )
+
       use session_id <- decode.field("session_id", decode.string)
       use resume_gateway_url <- decode.field(
         "resume_gateway_url",
         decode.string,
       )
 
-      decode.success(ReadyData(v:, user:, session_id:, resume_gateway_url:))
+      decode.success(ReadyData(
+        v:,
+        user:,
+        guilds:,
+        session_id:,
+        resume_gateway_url:,
+      ))
     })
 
     decode.success(ReadyPacket(t:, s:, op:, d:))

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -72,6 +72,7 @@ pub fn main(token: String, client_id: String, guild_id: String) {
 }
 
 fn handler(bot: bot.Bot, packet: event_handler.Packet) {
+  echo packet
   case packet {
     event_handler.ReadyPacket(ready) -> {
       logging.log(

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -92,7 +92,7 @@ fn handler(bot: bot.Bot, packet: event_handler.Packet) {
         request_guild_members.request_guild_members(
           bot,
           guild_id: id,
-          option: request_guild_members.UserIds(["698940360323366992"]),
+          option: request_guild_members.Query("", option.None),
           presences: option.Some(True),
           nonce: option.Some("test_request"),
         )

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -3,8 +3,10 @@ import discord_gleam
 import discord_gleam/discord/intents
 import discord_gleam/event_handler
 import discord_gleam/types/bot
+import discord_gleam/types/guild
 import discord_gleam/types/message
 import discord_gleam/types/slash_command
+import discord_gleam/ws/commands/request_guild_members
 import discord_gleam/ws/packets/interaction_create
 import gleam/bool
 import gleam/dict
@@ -82,6 +84,19 @@ fn handler(bot: bot.Bot, packet: event_handler.Packet) {
           <> "#"
           <> ready.d.user.discriminator,
       )
+
+      list.each(ready.d.guilds, fn(guild) {
+        let assert guild.UnavailableGuild(id, ..) = guild
+        logging.log(logging.Info, "Unavailable guild: " <> id)
+
+        request_guild_members.request_guild_members(
+          bot,
+          guild_id: id,
+          option: request_guild_members.UserIds(["698940360323366992"]),
+          presences: option.Some(True),
+          nonce: option.Some("test_request"),
+        )
+      })
 
       Nil
     }

--- a/test/example_bot.gleam
+++ b/test/example_bot.gleam
@@ -74,7 +74,6 @@ pub fn main(token: String, client_id: String, guild_id: String) {
 }
 
 fn handler(bot: bot.Bot, packet: event_handler.Packet) {
-  echo packet
   case packet {
     event_handler.ReadyPacket(ready) -> {
       logging.log(
@@ -644,6 +643,17 @@ fn handler(bot: bot.Bot, packet: event_handler.Packet) {
 
         _ -> Nil
       }
+    }
+
+    event_handler.PresenceUpdatePacket(presence) -> {
+      logging.log(logging.Info, "Presence updated for: " <> presence.d.user.id)
+    }
+
+    event_handler.GuildMembersChunkPacket(chunk) -> {
+      logging.log(
+        logging.Info,
+        "Guild members chunk received: " <> chunk.d.guild_id,
+      )
     }
 
     _ -> Nil


### PR DESCRIPTION
@cyteon I have some silly project idea, and to finish it I need some events to be implemented. 

Right now, here's what we have:
- Implemented `guild_presences` intent
- Added `websocket_name`  field to `Bot` type, as it was easy way to implement support for `send events`. 
- There is new folder in `ws` called `commands` (maybe better naming here?) where these send events could be stored. Implemented `request_guild_members` send event in there.
- Added support for `guild_members_chunk` packets.

I also want to implement `guild_member_add` and `guild_member_update`, so my pr is not fully done yet. Feel free to check the proposed code and say if there is something that you dont like there!