### PR TITLE
Rewrite deprecated `result.unrwap_both` with `case` expressions.

### DIFF
--- a/src/stratus/internal/socket.gleam
+++ b/src/stratus/internal/socket.gleam
@@ -3,7 +3,6 @@ import gleam/dynamic/decode
 import gleam/erlang/atom.{type Atom}
 import gleam/erlang/process.{type Selector}
 import gleam/list
-import gleam/result
 
 pub type Socket
 
@@ -146,26 +145,20 @@ pub fn selector() -> Selector(Result(SocketMessage, List(decode.DecodeError))) {
   |> process.select_record(TcpError, 2, fn(data) {
     {
       use reason <- decode.field(2, atom.decoder())
-      parse_known_socket_reason(reason)
-      |> result.map(Err)
-      |> result.map(decode.success)
-      |> result.map_error(fn(_data) {
-        decode.failure(Err(Badarg), "SocketReason")
-      })
-      |> result.unwrap_both
+      case parse_known_socket_reason(reason) {
+        Ok(r) -> decode.success(Err(r))
+        Error(_) -> decode.failure(Err(Badarg), "SocketReason")
+      }
     }
     |> decode.run(data, _)
   })
   |> process.select_record(SslError, 2, fn(data) {
     {
       use reason <- decode.field(2, atom.decoder())
-      parse_known_socket_reason(reason)
-      |> result.map(Err)
-      |> result.map(decode.success)
-      |> result.map_error(fn(_data) {
-        decode.failure(Err(Badarg), "SocketReason")
-      })
-      |> result.unwrap_both
+      case parse_known_socket_reason(reason) {
+        Ok(r) -> decode.success(Err(r))
+        Error(_) -> decode.failure(Err(Badarg), "SocketReason")
+      }
     }
     |> decode.run(data, _)
   })


### PR DESCRIPTION
Changed the usage of `result.unwrap_both` to `case ... {}` as it is no longer supported in Gleam 1.14.0 and emits a compiler error.
#26